### PR TITLE
This will fix the error in Magento2.3 where the Twig/Loader/LoaderInterface instance cannot be created/found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "schumacherfm/magento-twig",
     "description": "Twig template engine for Magento 2",
     "require": {
-        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
+        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0|~7.3.0",
         "magento/framework": ">=100.0.0",
         "magento/module-backend": ">=100.0.0",
         "magento/module-config": ">=100.0.0",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,6 +7,15 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Twig\Loader\FilesystemLoader">
+        <arguments>
+            <argument name="paths" xsi:type="string">../</argument>
+        </arguments>
+    </type>
+
+    <preference for="Twig\Loader\LoaderInterface" type="Twig\Loader\FilesystemLoader"/>
+
     <type name="Magento\Framework\View\Element\Template">
         <plugin name="convert_to_twig" type="SchumacherFM\Twig\Plugin\TemplatePlugin" sortOrder="0" />
     </type>


### PR DESCRIPTION
The argument is so it can load from the theme directory.