### PR TITLE
Add Magento 2.3.5 Support

### DIFF
--- a/Framework/View/TemplateEngine/Twig.php
+++ b/Framework/View/TemplateEngine/Twig.php
@@ -120,9 +120,8 @@ class Twig extends Php
     /**
      * @return mixed
      */
-    public function catchGet()
+    public function catchGet(...$args)
     {
-        $args = func_get_args();
         $name = array_shift($args);
         return $this->__call('get' . $name, $args);
     }

--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -4,11 +4,22 @@ namespace SchumacherFM\Twig\Twig\Loader;
 
 class FilesystemLoader extends \Twig\Loader\FilesystemLoader
 {
+    
     public function __construct($paths = [], \Magento\Framework\Filesystem\DirectoryList $directoryList)
     {
         $paths[] = './';
         parent::__construct($paths, $directoryList->getRoot());
     }
 
-
+    protected function findTemplate($name, $throw = true)
+    {
+        if(stristr($name, "::") !== false) {
+            $t = $this->resolver->getTemplateFileName($name);
+            $t = str_replace($this->directoryList->getPath(DirectoryList::ROOT) . DIRECTORY_SEPARATOR, '', $t);
+            return parent::findTemplate($t, $throw);
+        } else {
+            return parent::findTemplate($name, $throw);
+        }
+    }
+    
 }

--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -4,9 +4,18 @@ namespace SchumacherFM\Twig\Twig\Loader;
 
 class FilesystemLoader extends \Twig\Loader\FilesystemLoader
 {
-    
-    public function __construct($paths = [], \Magento\Framework\Filesystem\DirectoryList $directoryList)
+
+    protected $directoryList;
+
+    protected $resolver;
+
+    public function __construct(
+        \Magento\Framework\Filesystem\DirectoryList $directoryList,
+        \Magento\Framework\View\Element\Template\File\Resolver $resolver,
+        $paths = [])
     {
+        $this->directoryList = $directoryList;
+        $this->resolver = $resolver;
         $paths[] = './';
         parent::__construct($paths, $directoryList->getRoot());
     }
@@ -21,5 +30,6 @@ class FilesystemLoader extends \Twig\Loader\FilesystemLoader
             return parent::findTemplate($name, $throw);
         }
     }
-    
+
 }
+

--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SchumacherFM\Twig\Twig\Loader;
+
+class FilesystemLoader extends \Twig\Loader\FilesystemLoader
+{
+    public function __construct($paths = [], \Magento\Framework\Filesystem\DirectoryList $directoryList)
+    {
+        $paths[] = './';
+        parent::__construct($paths, $directoryList->getRoot());
+    }
+
+
+}

--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -2,18 +2,34 @@
 
 namespace SchumacherFM\Twig\Twig\Loader;
 
+use Magento\Framework\Filesystem\DirectoryList;
+use Magento\Framework\View\Element\Template\File\Resolver;
+
 class FilesystemLoader extends \Twig\Loader\FilesystemLoader
 {
 
+    /**
+     * @var DirectoryList
+     */
     protected $directoryList;
 
+    /**
+     * @var Resolver
+     */
     protected $resolver;
 
+    /**
+     * FilesystemLoader constructor.
+     *
+     * @param DirectoryList $directoryList
+     * @param Resolver      $resolver
+     * @param array         $paths
+     */
     public function __construct(
-        \Magento\Framework\Filesystem\DirectoryList $directoryList,
-        \Magento\Framework\View\Element\Template\File\Resolver $resolver,
-        $paths = [])
-    {
+        DirectoryList $directoryList,
+        Resolver $resolver,
+        $paths = []
+    ) {
         $this->directoryList = $directoryList;
         $this->resolver = $resolver;
         $paths[] = './';
@@ -22,14 +38,13 @@ class FilesystemLoader extends \Twig\Loader\FilesystemLoader
 
     protected function findTemplate($name, $throw = true)
     {
-        if(stristr($name, "::") !== false) {
-            $t = $this->resolver->getTemplateFileName($name);
-            $t = str_replace($this->directoryList->getPath(DirectoryList::ROOT) . DIRECTORY_SEPARATOR, '', $t);
-            return parent::findTemplate($t, $throw);
+        if(stristr($name, '::') !== false) {
+            $templateName = $this->resolver->getTemplateFileName($name);
+            $templateName = str_replace($this->directoryList->getPath(DirectoryList::ROOT) . DIRECTORY_SEPARATOR, '', $templateName);
+            return parent::findTemplate($templateName, $throw);
         } else {
             return parent::findTemplate($name, $throw);
         }
     }
 
 }
-

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -8,13 +8,7 @@
         </arguments>
     </type>
 
-    <type name="Twig\Loader\FilesystemLoader">
-        <arguments>
-            <argument name="paths" xsi:type="string">../</argument>
-        </arguments>
-    </type>
-
-    <preference for="Twig\Loader\LoaderInterface" type="Twig\Loader\FilesystemLoader"/>
+    <preference for="Twig\Loader\LoaderInterface" type="SchumacherFM\Twig\Twig\Loader\FilesystemLoader"/>
 
     <type name="Magento\Framework\View\Element\Template">
         <plugin name="convert_to_twig" type="SchumacherFM\Twig\Plugin\TemplatePlugin" sortOrder="0" />


### PR DESCRIPTION
Hi,

this PR fixes two tiny bugs: 

* `catchGet` function does not get the function arguments due to a new plugin in 2.3.5.
* Fixed a bug where the template could not be found. New `FilesystemLoader`

Thanks again for supporting and mainting this extension. 